### PR TITLE
Fixed OperatorCollection and SubOperatorConfig labels 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,8 @@ This project uses the "Git flow" Git branching strategy for development and rele
 To contribute code or documentation, you should first create a fork of this repo, and once the feature is complete, 
 submit a [pull request](https://github.com/IBM/operator-collection-sdk/pulls) to the `develop` branch.
 
+Please refer to the [Development Guide](docs/development-guide.md), for further guidance during development.
+
 
 ### Proposing new features
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -1,0 +1,54 @@
+# Operator Collection Development Guide <!-- omit from toc -->
+
+## Table of Contents
+- [Testing changes in a forked repo](#testing-changes-in-a-forked-repo)
+  - [Installing local collection](#installing-local-collection)
+  - [Installing from forked Github repo](#installing-from-forked-github-repo)
+- [Ansible Molecule Setup](#ansible-molecule-setup)
+- [Writing Molecule Tests](#writing-molecule-tests)
+
+# Testing changes in a forked repo
+When working in a forked repository, there may be times where performing the `ansible-playbook` command from within the OC SDK collection is restricted, since most playbooks are required to be executed from the root of another Operator Collection. This requires that the OC SDK collection be installed globally, and below are the steps to do so.
+
+## Installing local collection
+From the `operator-collection-sdk/ibm` directory issue the following command:
+```bash
+ansible-galaxy collection install ./operator_collection_sdk -f
+```
+
+## Installing from forked Github repo
+```bash
+BRANCH_NAME=$(git branch | grep -F '*' | cut -d ' ' -f2)
+REPO_URL=$(git config --get remote.origin.url)
+ansible-galaxy collection install git+${REPO_URL}#ibm/operator_collection_sdk,${BRANCH_NAME} -f
+```
+
+# Ansible Molecule Setup
+The steps below describe how to setup Ansible Molecule in a vitrual environment on your machine.
+- Install virtualenv.
+    ```bash
+    pip install virtualenv
+    ```  
+- Create a vitualenv directory in your project.
+    ```bash
+    virtualenv ansible_venv
+    ```
+- Navigate to the new virtual environment directory.
+    ```bash
+    cd ansible_venv
+    ```
+- Activate the virtual environment.
+    ```bash
+    source bin/activate
+    ```
+- Install the following packages after activating the virtual environment.
+    ```bash
+    pip install molecule ansible docker kubernetes
+    ```
+- Navigate to the `playbooks` directory to execute the available Molecule scenarios. Example:
+    ```bash
+    cd ../playbooks
+    molecule test -s init_collection
+- When you are ready to exit the virtual environment, simply execute the `deactivate` command to exit.
+
+# Writing Molecule Tests

--- a/ibm/operator_collection_sdk/galaxy.yml
+++ b/ibm/operator_collection_sdk/galaxy.yml
@@ -8,7 +8,7 @@ namespace: ibm
 name: operator_collection_sdk
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.3.0-beta.1
+version: 1.0.0-beta.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/ibm/operator_collection_sdk/galaxy.yml
+++ b/ibm/operator_collection_sdk/galaxy.yml
@@ -8,7 +8,7 @@ namespace: ibm
 name: operator_collection_sdk
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.2.0
+version: 0.3.0-beta.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/ibm/operator_collection_sdk/playbooks/create_operator.yml
+++ b/ibm/operator_collection_sdk/playbooks/create_operator.yml
@@ -123,12 +123,6 @@
           metadata:
             name: "{{ operatorcollection_name }}-soc"
             namespace: "{{ target_namespace }}"
-            labels:
-              managed-by: ibm-zos-cloud-broker
-              operator-domain: "{{ operator_domain }}"
-              operator-name: "{{ operator_name }}"
-              operator-version: "{{ operator_version }}"
-              operatorcollection-name: "{{ operator_name }}.{{ operator_domain }}.{{ operator_version }}"
           spec:
             credentialType: personal
             mapping:
@@ -147,12 +141,6 @@
           metadata:
             name: "{{ operatorcollection_name }}-soc"
             namespace: "{{ target_namespace }}"
-            labels:
-              managed-by: ibm-zos-cloud-broker
-              operator-domain: "{{ operator_domain }}"
-              operator-name: "{{ operator_name }}"
-              operator-version: "{{ operator_version }}"
-              operatorcollection-name: "{{ operator_name }}.{{ operator_domain }}.{{ operator_version }}"
           spec:
             credentialType: shared
             mapping:


### PR DESCRIPTION
This fix allows for the proper labels to be applied to the `OperatorCollection` and `SubOperatorConfig` by removing the default labels and allowing them to be applied automatically by the broker. This resolves an issue where the `SubOperatorConfig` wasn't owned by the `OperatorCollection` resource, causing `SubOpertorConfigs` to be orphaned when `OperatorCollections` were deleted