### PR TITLE
Remove galaxy.yml validation for create_offline_requirements playbook

### DIFF
--- a/ibm/operator_collection_sdk/galaxy.yml
+++ b/ibm/operator_collection_sdk/galaxy.yml
@@ -8,7 +8,7 @@ namespace: ibm
 name: operator_collection_sdk
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.1-beta.1
+version: 1.1.0-beta.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/ibm/operator_collection_sdk/galaxy.yml
+++ b/ibm/operator_collection_sdk/galaxy.yml
@@ -8,7 +8,7 @@ namespace: ibm
 name: operator_collection_sdk
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.0-beta.1
+version: 1.0.1-beta.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/ibm/operator_collection_sdk/playbooks/create_offline_requirements.yml
+++ b/ibm/operator_collection_sdk/playbooks/create_offline_requirements.yml
@@ -14,17 +14,6 @@
       ansible.builtin.set_fact:
         local_directory: "{{ lookup('env', 'PWD') if filepath is undefined else filepath }}"
 
-    - name: Locate galaxy.yml file
-      ansible.builtin.find:
-        paths: "{{ local_directory }}"
-        patterns: 'galaxy.yml,galaxy.yaml'
-      register: galaxy_file_results
-
-    - name: Validate galaxy.yml file exists in current working directory
-      ansible.builtin.fail:
-        msg: "Collection must be executed in same directory as galaxy.yml file"
-      when: galaxy_file_results.files | length == 0
-
     - name: Locate operator-config.yml file
       ansible.builtin.find:
         paths: "{{ local_directory }}"

--- a/ibm/operator_collection_sdk/playbooks/molecule/create_offline_requirements/converge.yml
+++ b/ibm/operator_collection_sdk/playbooks/molecule/create_offline_requirements/converge.yml
@@ -14,6 +14,11 @@
         src: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/../../../examples/racf-operator"
         dest: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/../../../examples/racf-operator-test"
 
+    - name: Remove galaxy.yaml file
+      ansible.builtin.file:
+        path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/../../../examples/racf-operator-test/operator-config.yml"
+        state: absent
+
 - import_playbook: ../../create_offline_requirements.yml
   vars:
     filepath: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/../../../examples/racf-operator-test/racf-operator"

--- a/ibm/operator_collection_sdk/playbooks/redeploy_collection.yml
+++ b/ibm/operator_collection_sdk/playbooks/redeploy_collection.yml
@@ -14,6 +14,10 @@
       ansible.builtin.set_fact:
         local_directory: "{{ lookup('env', 'PWD') if filepath is undefined else filepath }}"
 
+    - name: Print local_directory variable
+      ansible.builtin.debug:
+        msg: "{{ local_directory }}"
+
     - name: Prereq Validation
       ansible.builtin.include_role:
         name: pre_check

--- a/ibm/operator_collection_sdk/playbooks/redeploy_collection.yml
+++ b/ibm/operator_collection_sdk/playbooks/redeploy_collection.yml
@@ -13,6 +13,7 @@
     - name: Print filepath variable
       ansible.builtin.debug:
         msg: "{{ filepath }}"
+      when: filepath is defined
 
     - name: Set local directory
       ansible.builtin.set_fact:

--- a/ibm/operator_collection_sdk/playbooks/redeploy_collection.yml
+++ b/ibm/operator_collection_sdk/playbooks/redeploy_collection.yml
@@ -10,6 +10,10 @@
   gather_facts: false
 
   tasks:
+    - name: Print filepath variable
+      ansible.builtin.debug:
+        msg: "{{ filepath }}"
+
     - name: Set local directory
       ansible.builtin.set_fact:
         local_directory: "{{ lookup('env', 'PWD') if filepath is undefined else filepath }}"

--- a/ibm/operator_collection_sdk/playbooks/redeploy_collection.yml
+++ b/ibm/operator_collection_sdk/playbooks/redeploy_collection.yml
@@ -10,18 +10,9 @@
   gather_facts: false
 
   tasks:
-    - name: Print filepath variable
-      ansible.builtin.debug:
-        msg: "{{ filepath }}"
-      when: filepath is defined
-
     - name: Set local directory
       ansible.builtin.set_fact:
         local_directory: "{{ lookup('env', 'PWD') if filepath is undefined else filepath }}"
-
-    - name: Print local_directory variable
-      ansible.builtin.debug:
-        msg: "{{ local_directory }}"
 
     - name: Prereq Validation
       ansible.builtin.include_role:


### PR DESCRIPTION
To support the conversion of Operator Collections pulled directly from Ansible Galaxy, I'm removing the `galaxy.yml` file validation since this file doesn't exist in collections published to Galaxy