### PR TITLE
Disable signature validation when redeploying operator

### DIFF
--- a/ibm/operator_collection_sdk/README.md
+++ b/ibm/operator_collection_sdk/README.md
@@ -94,8 +94,6 @@ If your local environment is also offline, then you must download the required A
 ansible-playbook ibm.operator_collection_sdk.create_offline_requirements
 ```
 
-**Note:** Offline Python dependencies are currently not supported in the v2.2.2 release of the IBM z/OS Cloud Broker, so the `requirements.txt` file will be removed in the Operator Collection once it has been converted to execute offline. 
-
 
 # Usage Examples
 **Note:** To execute this playbook, it is required that your are in the root directory of the collection that you are developing, with a valid `galaxy.yml` and `operator-config.yml` file in the same directory

--- a/ibm/operator_collection_sdk/galaxy.yml
+++ b/ibm/operator_collection_sdk/galaxy.yml
@@ -8,7 +8,7 @@ namespace: ibm
 name: operator_collection_sdk
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.1.0
+version: 1.1.1-beta.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/ibm/operator_collection_sdk/playbooks/molecule/create_operator_local/converge.yml
+++ b/ibm/operator_collection_sdk/playbooks/molecule/create_operator_local/converge.yml
@@ -49,7 +49,7 @@
             name: ibm-zoscb
             source: ibm-operator-catalog
             sourceNamespace: openshift-marketplace
-            startingCSV: ibm-zoscb.v2.2.2
+            startingCSV: ibm-zoscb.v2.2.3
 
     - name: Validate Subscription installed successfully
       kubernetes.core.k8s_info:

--- a/ibm/operator_collection_sdk/playbooks/molecule/create_redeploy_delete_operator/converge.yml
+++ b/ibm/operator_collection_sdk/playbooks/molecule/create_redeploy_delete_operator/converge.yml
@@ -49,7 +49,7 @@
             name: ibm-zoscb
             source: ibm-operator-catalog
             sourceNamespace: openshift-marketplace
-            startingCSV: ibm-zoscb.v2.2.2
+            startingCSV: ibm-zoscb.v2.2.3
 
     - name: Validate Subscription installed successfully
       kubernetes.core.k8s_info:

--- a/ibm/operator_collection_sdk/playbooks/redeploy_operator.yml
+++ b/ibm/operator_collection_sdk/playbooks/redeploy_operator.yml
@@ -100,7 +100,8 @@
             name: "{{ oc_results.resources[0].metadata.name }}"
             namespace: "{{ target_namespace }}"
             labels: "{{ oc_results.resources[0].metadata.labels }}"
-          spec: "{{ oc_results.resources[0].spec }}"
+          spec:
+            skipSignatureVerification: true
 
     - name: Validate OperatorCollection installed successfully
       kubernetes.core.k8s_info:


### PR DESCRIPTION
This resolves an issue where if an Operator Collection was deployed by the broker using a signature secret, then the redeploy would fail. This fix will remove the mapped signature secret name since developing an Operator Collection with a signature would restrict modifications to the playbook on the filesystem.