### PR TITLE
ansible.utils.unsafe_proxy.AnsibleUnsafeText fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,3 +97,4 @@ jobs:
         env:
             OPENSHIFT_SERVER: ${{ secrets.OPENSHIFT_SERVER }}
             OPENSHIFT_TOKEN: ${{ secrets.OPENSHIFT_TOKEN }}
+            ZOSCB_RELEASE: ibm-zoscb.${{ vars.ZOSCB_RELEASE }}

--- a/ibm/operator_collection_sdk/playbooks/molecule/create_operator_local/converge.yml
+++ b/ibm/operator_collection_sdk/playbooks/molecule/create_operator_local/converge.yml
@@ -49,7 +49,7 @@
             name: ibm-zoscb
             source: ibm-operator-catalog
             sourceNamespace: openshift-marketplace
-            startingCSV: ibm-zoscb.v2.2.3
+            startingCSV: "{{ zoscb_release }}"
 
     - name: Validate Subscription installed successfully
       kubernetes.core.k8s_info:

--- a/ibm/operator_collection_sdk/playbooks/molecule/create_operator_local/molecule.yml
+++ b/ibm/operator_collection_sdk/playbooks/molecule/create_operator_local/molecule.yml
@@ -30,6 +30,7 @@ provisioner:
         zosendpoint_name: ibmcloud-vm
         openshift_token: ${OPENSHIFT_TOKEN}
         openshift_server: ${OPENSHIFT_SERVER}
+        zoscb_release: ${ZOSCB_RELEASE:-ibm-zoscb.v2.2.4}
 scenario:
   test_sequence:
     - prepare

--- a/ibm/operator_collection_sdk/playbooks/molecule/create_redeploy_delete_operator/converge.yml
+++ b/ibm/operator_collection_sdk/playbooks/molecule/create_redeploy_delete_operator/converge.yml
@@ -49,7 +49,7 @@
             name: ibm-zoscb
             source: ibm-operator-catalog
             sourceNamespace: openshift-marketplace
-            startingCSV: ibm-zoscb.v2.2.3
+            startingCSV: "{{ zoscb_release }}"
 
     - name: Validate Subscription installed successfully
       kubernetes.core.k8s_info:

--- a/ibm/operator_collection_sdk/playbooks/molecule/create_redeploy_delete_operator/molecule.yml
+++ b/ibm/operator_collection_sdk/playbooks/molecule/create_redeploy_delete_operator/molecule.yml
@@ -31,6 +31,7 @@ provisioner:
         secret_name: "test-secret"
         openshift_token: ${OPENSHIFT_TOKEN}
         openshift_server: ${OPENSHIFT_SERVER}
+        zoscb_release: ${ZOSCB_RELEASE:-ibm-zoscb.v2.2.4}
         skip_credential_check: true
 scenario:
   test_sequence:

--- a/ibm/operator_collection_sdk/playbooks/roles/pre_check/tasks/main.yml
+++ b/ibm/operator_collection_sdk/playbooks/roles/pre_check/tasks/main.yml
@@ -52,7 +52,7 @@
 
 - name: Read operator-config.yml
   ansible.builtin.set_fact:
-    operator_config: "{{ lookup('template', '{{ oc_file_results.files[0].path }}')|from_yaml }}"
+    operator_config: "{{ lookup('template', '{{ oc_file_results.files[0].path }}')| from_yaml | to_json | from_json }}"
 
 - name: Set operator variables
   ansible.builtin.set_fact:


### PR DESCRIPTION
When attempting to execute the `delete_operator` or `redeploy_collection` playbook, the follow error occurs

```
'ansible.utils.unsafe_proxy.AnsibleUnsafeText object' has no attribute 'name'
```

No idea what could've changed recently to cause this error, because this was working fine in the previous releases.